### PR TITLE
fix(portal): incorrect display mobile sidebar

### DIFF
--- a/apps/frontend/portal/src/layout/RootLayoutMenuRender.tsx
+++ b/apps/frontend/portal/src/layout/RootLayoutMenuRender.tsx
@@ -23,7 +23,7 @@ export const RootLayoutMenuRender = (
   });
 
   return (
-    <div className={cn('flex gap-1', className)}>
+    <div className={cn('flex flex-col gap-3 md:flex-row md:gap-1', className)}>
       {resolvedItems.map((item) => {
         const Icon = NAV_ICONS[item.to];
         return (

--- a/apps/frontend/portal/src/layout/RootLayoutSidebar.tsx
+++ b/apps/frontend/portal/src/layout/RootLayoutSidebar.tsx
@@ -1,5 +1,6 @@
-import { Drawer, useMediaQuery, useTheme } from '@mui/material';
+import { Drawer, useMediaQuery, useTheme, type Theme } from '@mui/material';
 import { LanguageSelector } from '@pawhaven/frontend-core';
+import { useEffect } from 'react';
 import type { NavigateFunction } from 'react-router-dom';
 
 import { RootLayoutMenuRender } from './RootLayoutMenuRender';
@@ -19,8 +20,14 @@ export const RootLayoutSidebar = ({
   onCloseSidebar,
   navigate,
 }: RootLayoutSidebarProps) => {
-  const theme = useTheme();
-  const Desktop = useMediaQuery('(min-width: 768px)');
+  const theme: Theme = useTheme();
+  const isDesktop: boolean = useMediaQuery('(min-width: 768px)');
+
+  useEffect(() => {
+    if (isDesktop && isSidebarOpen) {
+      onCloseSidebar();
+    }
+  }, [isDesktop, isSidebarOpen, onCloseSidebar]);
 
   const navigateAndClose: NavigateFunction = (...args) => {
     onCloseSidebar();
@@ -30,10 +37,10 @@ export const RootLayoutSidebar = ({
 
   return (
     <Drawer
-      open={Desktop ? false : isSidebarOpen}
+      open={isDesktop ? false : isSidebarOpen}
       transitionDuration={{
         enter: theme.transitions.duration.enteringScreen,
-        exit: Desktop ? 0 : theme.transitions.duration.leavingScreen,
+        exit: isDesktop ? 0 : theme.transitions.duration.leavingScreen,
       }}
       anchor="right"
       onClose={onCloseSidebar}

--- a/apps/frontend/portal/src/layout/RootLayoutSidebar.tsx
+++ b/apps/frontend/portal/src/layout/RootLayoutSidebar.tsx
@@ -1,4 +1,4 @@
-import { Drawer } from '@mui/material';
+import { Drawer, useMediaQuery, useTheme } from '@mui/material';
 import { LanguageSelector } from '@pawhaven/frontend-core';
 import type { NavigateFunction } from 'react-router-dom';
 
@@ -19,6 +19,9 @@ export const RootLayoutSidebar = ({
   onCloseSidebar,
   navigate,
 }: RootLayoutSidebarProps) => {
+  const theme = useTheme();
+  const Desktop = useMediaQuery('(min-width: 768px)');
+
   const navigateAndClose: NavigateFunction = (...args) => {
     onCloseSidebar();
     // @ts-expect-error: react-router types are complex, spreading args is safe
@@ -27,10 +30,14 @@ export const RootLayoutSidebar = ({
 
   return (
     <Drawer
-      open={isSidebarOpen}
+      open={Desktop ? false : isSidebarOpen}
+      transitionDuration={{
+        enter: theme.transitions.duration.enteringScreen,
+        exit: Desktop ? 0 : theme.transitions.duration.leavingScreen,
+      }}
       anchor="right"
       onClose={onCloseSidebar}
-      PaperProps={{ className: 'h-full bg-background text-text pt-7' }}
+      PaperProps={{ className: 'h-full bg-background text-text p-7' }}
     >
       <div className="flex justify-end px-4 pb-4">
         <LanguageSelector />


### PR DESCRIPTION
Resolves #60

Sidebar closes and opens smoothly, and navigation stacks vertically on mobile.
The last recording may appear slightly choppy due to screen capture, but the sidebar behavior changes are visible in the video.

## Before:
https://github.com/user-attachments/assets/7e598977-6d54-43d2-b06d-da125b7ce82d

## After:
https://github.com/user-attachments/assets/3225511a-0a77-4391-8921-76de700d93d2

##  Sidebar closes automatically when switching to desktop:
https://github.com/user-attachments/assets/04ad6693-2530-4f6b-ba73-29263c268877











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated sidebar navigation for smoother behavior across desktop and smaller screens.
  * Improved menu spacing and responsive layout across screen sizes.
  * Preserved sidebar state on smaller screens and refined drawer spacing and transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->